### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = ""

--- a/README.md
+++ b/README.md
@@ -34,3 +34,5 @@ To create a production optimised build run the command below:
     npm run build
                                                         
 This created another folder in the root of your project named build. You'll have an option to start a local web server to view your newly created production build.
+
+[![Run on Repl.it](https://repl.it/badge/github/apathre/dashboardTest)](https://repl.it/github/apathre/dashboardTest)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@AdityaPathre/dashboardTest-1).